### PR TITLE
Add on-demand retry for "not found in MLB database" players (v5.4.9)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1268,7 +1268,7 @@
                 <div>
                     <h1>🎯 Prospect Scouting Dashboard</h1>
                     <p style="color: #94a3b8;">Advanced analytics, level-by-level stats, performance trends & scouting insights</p>
-                    <p style="color: #64748b; font-size: 0.875rem; margin-top: 5px;">v5.4.8 - Year-by-Year Breakdown Matches Too</p>
+                    <p style="color: #64748b; font-size: 0.875rem; margin-top: 5px;">v5.4.9 - Retry MLB Lookups On Demand</p>
                     
                     <!-- Data Status Indicators -->
                     <div id="dataStatus" style="display: flex; gap: 15px; margin-top: 10px; font-size: 0.875rem;">
@@ -1990,7 +1990,15 @@
                     <h3 style="color: #a78bfa; margin-bottom: 15px;">📜 Version History</h3>
                     
                     <div style="margin-bottom: 15px;">
-                        <h4 style="color: #22c55e; margin-bottom: 8px;">v5.4.8 - Year-by-Year Breakdown Matches Too 📋 (Current)</h4>
+                        <h4 style="color: #22c55e; margin-bottom: 8px;">v5.4.9 - Retry MLB Lookups On Demand 🔄 (Current)</h4>
+                        <ul style="color: #cbd5e1; line-height: 1.6; margin-left: 20px; font-size: 0.875rem;">
+                            <li>❓ Answers a question about "not found in MLB database" players: this was never permanently stuck - reloading the page (or a "Refresh Roster") already retries every player fresh, since that result was only ever remembered for your current browser tab, not saved to your cached roster</li>
+                            <li>🔄 Added a "Check MLB Database Again" button right on the not-found card, so you can force that same retry for one player - useful once a recent draft pick or international signee actually shows up in the MLB Stats API - without reloading your whole roster</li>
+                        </ul>
+                    </div>
+
+                    <div style="margin-bottom: 15px;">
+                        <h4 style="color: #60a5fa; margin-bottom: 8px;">v5.4.8 - Year-by-Year Breakdown Matches Too 📋</h4>
                         <ul style="color: #cbd5e1; line-height: 1.6; margin-left: 20px; font-size: 0.875rem;">
                             <li>🐛 The Year-by-Year Breakdown's per-year total still included our own TC/arbitration salary estimates, so it didn't match the official Cap Used number now shown above it (e.g. SF's 2027 breakdown read $235.5M against an official $125.5M)</li>
                             <li>✅ The breakdown's main total and player list now only count players with a real dollar figure from the sheet - the same players the league's official total counts - so the two numbers line up</li>
@@ -5832,7 +5840,7 @@
         function updatePlayerCard(safeId) {
             const content = document.getElementById(`content-${safeId}`);
             const player = players.find(p => getSafeId(p.id) === safeId);
-            
+
             if (!player) {
                 console.error(`Player not found for safe ID: ${safeId}`);
                 return;
@@ -5842,11 +5850,14 @@
                 let errorHTML = `<div class="error-msg">${player.stats.error}`;
                 if (player.stats.showSearchLink) {
                     errorHTML += `<br><br>
-                        <a href="https://www.google.com/search?q=${encodeURIComponent(player.name + ' baseball stats')}" 
-                           target="_blank" class="search-link">
+                        <button class="search-link" style="cursor: pointer; border: none;" onclick="retryPlayerStats('${safeId}')">
+                            🔄 Check MLB Database Again
+                        </button>
+                        <a href="https://www.google.com/search?q=${encodeURIComponent(player.name + ' baseball stats')}"
+                           target="_blank" class="search-link" style="margin-left: 10px;">
                             🔍 Search Google for "${player.name}"
                         </a>
-                        <a href="https://www.baseball-reference.com/search/search.fcgi?search=${encodeURIComponent(player.name)}" 
+                        <a href="https://www.baseball-reference.com/search/search.fcgi?search=${encodeURIComponent(player.name)}"
                            target="_blank" class="search-link" style="margin-left: 10px;">
                             📊 Search Baseball Reference
                         </a>`;
@@ -5857,6 +5868,28 @@
             }
 
             updatePlayerCardContent(safeId, player);
+        }
+
+        // A "not found" result from fetchPlayerStats is only ever remembered in-memory for
+        // this tab (never written to the roster's localStorage cache), so a page reload
+        // already retries every player fresh. This lets you force that same retry for one
+        // player right now, without reloading the whole roster - useful once a recent draft
+        // pick/international signee actually shows up in the MLB Stats API.
+        async function retryPlayerStats(safeId) {
+            const player = players.find(p => getSafeId(p.id) === safeId);
+            if (!player) return;
+
+            player.stats = null;
+            player.statsLoaded = false;
+
+            const content = document.getElementById(`content-${safeId}`);
+            if (content) {
+                content.innerHTML = '<div class="loading"><div class="spinner"></div><p>Checking MLB database...</p></div>';
+            }
+
+            await fetchPlayerStats(player);
+            player.statsVersion = STATS_VERSION;
+            updatePlayerCard(safeId);
         }
 
         function renderHitterStats(stats, isSeason) {


### PR DESCRIPTION
## Summary

Answers the question: is a "not found in MLB database" result (like "Cremarosa, Aidan") hardcoded to never check again, or would it pick up real stats once the player actually shows up in MLB's system?

Traced the two caches involved:
- **MLB bio enrichment** (the team/age badges shown on the collapsed card) is cached in `mlbPlayerBioCache` with a 24h TTL, including "not found" results - so it's automatically rechecked on the next roster sync more than 24h later. Not permanently stuck.
- **The on-demand stats lookup** (the red "not found" error box shown when a card is expanded) isn't persisted to `localStorage` at all - it only lives in memory for the current browser tab. Reloading the page or doing a "Refresh Roster" produces brand-new player objects with `statsLoaded: false`, so the very next time that card is opened, it retries the MLB Stats API fresh automatically.

So nothing was actually hardcoded forever - but there was no way to force a recheck for one specific player without reloading the whole page/roster. Added a "🔄 Check MLB Database Again" button directly on the error card that resets that one player's stats state and re-queries the MLB Stats API on the spot (`retryPlayerStats()`).

Bumped to v5.4.9 with a Guide tab changelog entry explaining the existing (already-correct) retry-on-reload behavior, plus the new on-demand button.

## Test plan
- [x] `node --check` on the extracted inline script
- [x] New harness test: seeded a player that returns empty from the MLB search API, confirmed the error card renders with the retry button, confirmed re-expanding the same card in-session does *not* refetch (existing per-session cache behavior preserved), then flipped the mock to return a real match and confirmed `retryPlayerStats()` triggers a fresh search call and correctly clears the error / populates real stats
- [x] Re-ran the full `harness_finances.js` suite (14 checks) - all pass, no regression

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01R8sjqK6CFpUUgq3pYimip8

---
_Generated by [Claude Code](https://claude.ai/code/session_01R8sjqK6CFpUUgq3pYimip8)_